### PR TITLE
Fix Auth0 login/signup redirect and callback flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import Navbar from "./components/Navbar";
+import Callback from "./pages/Callback";
 import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home/Home";
 import Coin from "./pages/Home/Coin/Coin";
@@ -33,6 +34,7 @@ const App = () => {
         <Route path="/blog/:id" element={<BlogDetail />} />
 
         <Route path="/features" element={<Features />} />
+        <Route path="/callback" element={<Callback />} />
       </Routes>
       <Footer />
     </div>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -5,7 +5,11 @@ function Login({ loginWithRedirect }) {
 
   return (
     <button
-      onClick={() => loginWithRedirect()}
+      onClick={() => loginWithRedirect({
+        authorizationParams: {
+          redirect_uri: window.location.origin + "/callback",
+        },
+      })}
       className="login-btn"
     >
       <span>Log In</span>

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -5,7 +5,12 @@ function Signup({ loginWithRedirect }) {
 
   return (
     <button
-      onClick={() => loginWithRedirect({ screen_hint: "signup" })}
+      onClick={() => loginWithRedirect({ 
+        authorizationParams: {
+          screen_hint: "signup",
+          redirect_uri: window.location.origin + "/callback",
+        }, 
+      })}
       className="signup-btn"
     >
       <span>Sign Up</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,7 +13,7 @@ createRoot(document.getElementById("root")).render(
         domain={import.meta.env.VITE_AUTH0_DOMAIN}
         clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
         authorizationParams={{
-          redirect_uri: window.location.origin,
+          redirect_uri: window.location.origin + "/callback",
         }}
         cacheLocation="localstorage"
         useRefreshTokens={true}

--- a/src/pages/Callback.jsx
+++ b/src/pages/Callback.jsx
@@ -1,0 +1,16 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Callback() {
+  const { isLoading } = useAuth0();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading) {
+      navigate("/");
+    }
+  }, [isLoading, navigate]);
+
+  return <p>Logging you in...</p>;
+}


### PR DESCRIPTION
# Fix Auth0 login & signup redirect flow

---

## 📌 Description
### What problem does it solve?
- The Login and Sign Up buttons were previously redirecting incorrectly, causing the app to show ERR_INTERNET_DISCONNECTED even when the internet was active.
- This broke the authentication flow and prevented users from logging in or signing up.

### What changes were made?
- Fixed the Sign Up button to pass screen_hint: "signup" inside authorizationParams, ensuring it opens the correct signup screen.
- Verified that Login opens the Auth0 login screen correctly.
- Callback route now properly redirects users back to the app homepage after login/signup.
- Auth0 pages remain external; dark/light mode does not apply, but theme resumes after returning to the app.

---

## 🔗 Related Issue
Closes #40 
---

## 🛠 Type of Change
<!-- Check the relevant option -->
- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature (adds new functionality)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation update

---

## ✅ Checklist
<!-- Ensure all items are completed before requesting review -->
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Tests added or updated (if applicable)
- [x] All tests passed locally
- [x] Documentation updated (if required)
- [x] No new warnings or errors introduced

---

## 🧪 Testing Done
### Test Cases Executed
- [x] Click **Login** → Auth0 login page opens → enters credentials → redirected back to app
- [x] Click **Sign Up** → Auth0 signup page opens → completes signup → redirected back to app
- [x] Callback route navigates correctly to homepage after login/signup

---

## 🗒 Additional Notes
- Known Limitations:
  - Dark/light mode does **not** apply on Auth0 login/signup pages since they are hosted externally. Theme resumes once users return to the app.

- Follow-up Tasks
    - Optional: Customize Auth0 Universal Login page branding to match app theme.
    - Ensure future API keys or secrets remain local and are **never committed**.