### PR TITLE
Add right-side filter panel for crypto listings

### DIFF
--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -101,6 +101,151 @@
     gap: 10px;
 }
 
+.filter-bar {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 10px;
+    margin-top: 10px;
+}
+
+/* Filter Button Icon */
+.filter-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px !important;
+    min-width: 50px;
+    background: linear-gradient(90deg, #7927ff 0%, #2193b0 100%) !important;
+    border: none;
+    border-radius: 7px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 8px #7927ff22;
+}
+
+.filter-btn:hover {
+    background: linear-gradient(90deg, #2193b0 0%, #7927ff 100%) !important;
+    transform: translateY(-2px) scale(1.04);
+    box-shadow: 0 4px 12px #7927ff44;
+}
+
+/* Filter Panel Container */
+.filter-panel {
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 0;
+    width: 280px;
+    background: linear-gradient(145deg, rgba(18, 18, 35, 0.95), rgba(30, 30, 50, 0.95));
+    border: 1px solid rgba(121, 39, 255, 0.3);
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.5), 0 0 20px rgba(121, 39, 255, 0.2);
+    backdrop-filter: blur(10px);
+    z-index: 1000;
+    animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.filter-group label {
+    font-size: 14px;
+    color: #e0e0e0;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.filter-group input,
+.filter-group select {
+    width: 100%;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    outline: none;
+    font-size: 14px;
+    transition: all 0.3s ease;
+}
+
+.filter-group input:focus,
+.filter-group select:focus {
+    border-color: rgba(121, 39, 255, 0.8);
+    background: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 0 0 3px rgba(121, 39, 255, 0.1);
+}
+
+.filter-group input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.filter-group select {
+    cursor: pointer;
+}
+
+.filter-group select:hover {
+    border-color: rgba(121, 39, 255, 0.6);
+}
+
+/* Filter Actions (Apply/Close buttons) */
+.filter-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 8px;
+}
+
+.filter-actions button {
+    flex: 1;
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.filter-actions button:first-child {
+    background: linear-gradient(90deg, #7927ff 0%, #2193b0 100%);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(121, 39, 255, 0.3);
+}
+
+.filter-actions button:first-child:hover {
+    background: linear-gradient(90deg, #2193b0 0%, #7927ff 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(121, 39, 255, 0.4);
+}
+
+.filter-actions button.reset {
+    background: rgba(255, 255, 255, 0.1);
+    color: #e0e0e0;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.filter-actions button.reset:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.3);
+    transform: translateY(-2px);
+}
+
 .hero input {
     flex: 1;
     font-size: 16px;
@@ -189,15 +334,13 @@
     }
 }
 
-/* ..........Load More button ........... */
 .load-more {
     display: flex;
     justify-content: center;
     margin-top: 30px;
-    /* Space from table */
+   
 }
 
-/* Main Button */
 .load-more button {
     padding: 14px 46px;
     font-size: 20px;
@@ -222,8 +365,37 @@
     background: linear-gradient(135deg, #00d4ff, #7f5cff);
 }
 
-/* Click Effect */
+
 .load-more button:active {
     transform: scale(0.96);
     box-shadow: 0 6px 18px rgba(127, 92, 255, 0.3);
+}
+
+
+.search-wrapper {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .filter-panel {
+        width: calc(100vw - 40px);
+        right: auto;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    .hero-form {
+        flex-wrap: nowrap;
+    }
+
+    .filter-btn {
+        padding: 8px 12px !important;
+        min-width: 45px;
+    }
 }

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,100 +1,161 @@
 import React, { useContext, useEffect, useState } from "react";
 import "./Home.css";
 import { CoinContext } from "../../context/CoinContext";
-import { Link } from 'react-router-dom'
+import { Link } from "react-router-dom";
+import { FiFilter } from "react-icons/fi";
 
 const Home = () => {
   const { allCoin, currency } = useContext(CoinContext);
+
   const [displayCoin, setDisplayCoin] = useState([]);
   const [input, setInput] = useState("");
   const [visibleCount, setVisibleCount] = useState(10);
-  const inputHandler = (event) => {
-    setInput(event.target.value);
-    if (event.target.value === "") {
-      setDisplayCoin(allCoin);
-    }
+  const [showFilters, setShowFilters] = useState(false);
+
+  const [minPrice, setMinPrice] = useState("");
+  const [maxPrice, setMaxPrice] = useState("");
+
+  const inputHandler = (e) => {
+    setInput(e.target.value);
+    if (e.target.value === "") setDisplayCoin(allCoin);
   };
 
-  const searchHandler = async (event) => {
-    event.preventDefault();
-    const coins = await allCoin.filter((item) => {
-      return item.name.toLowerCase().includes(input.toLowerCase());
-    });
-    setDisplayCoin(coins);
+  const searchHandler = (e) => {
+    e.preventDefault();
+    setDisplayCoin(
+      allCoin.filter((item) =>
+        item.name.toLowerCase().includes(input.toLowerCase())
+      )
+    );
+  };
+
+  const applyFilters = () => {
+    let filtered = [...allCoin];
+
+    if (minPrice)
+      filtered = filtered.filter(
+        (coin) => coin.current_price >= Number(minPrice)
+      );
+
+    if (maxPrice)
+      filtered = filtered.filter(
+        (coin) => coin.current_price <= Number(maxPrice)
+      );
+
+    setDisplayCoin(filtered);
+    setShowFilters(false);
   };
 
   useEffect(() => {
     setDisplayCoin(allCoin);
   }, [allCoin]);
-  const loadMoreHandler = () => {
-    setVisibleCount(prev => prev + 5);
-  };
-
 
   return (
     <div className="home">
       <div className="hero">
-        <h1 data-aos="fade-in" className="hero-title">Discover & Track Crypto Instantly</h1>
-        <p data-aos="fade-in" className="hero-sub">
-          Welcome to CryptoHub — your gateway to real-time prices, trending coins, and powerful analytics. Search any coin and start exploring the world of crypto!
+        <h1 className="hero-title">Discover & Track Crypto Instantly</h1>
+        <p className="hero-sub">
+          Welcome to CryptoHub — your gateway to real-time prices, trending coins,
+          and powerful analytics.
         </p>
-        <form data-aos="zoom-in" className="hero-form" onSubmit={searchHandler} autoComplete="off">
-          <input
-            onChange={inputHandler}
-            list="coinlist"
-            value={input}
-            type="text"
-            placeholder="Search for a coin..."
-            required
-          />
-          <datalist id="coinlist">
-            {allCoin && allCoin.map((item, index) => (<option key={index} value={item.name} />))}
-          </datalist>
-          <button type="submit">Search</button>
-        </form>
+
+        <div className="search-wrapper">
+          <form className="hero-form" onSubmit={searchHandler}>
+            <input
+              value={input}
+              onChange={inputHandler}
+              list="coinlist"
+              placeholder="Search for a coin..."
+              required
+            />
+
+            <datalist id="coinlist">
+              {allCoin?.map((c, i) => (
+                <option key={i} value={c.name} />
+              ))}
+            </datalist>
+
+            <button type="submit">Search</button>
+
+            <button
+              type="button"
+              className="filter-btn"
+              onClick={() => setShowFilters(!showFilters)}
+            >
+              <FiFilter size={20} />
+            </button>
+          </form>
+
+          {showFilters && (
+            <div className="filter-panel right">
+              
+
+              <div className="filter-group">
+                <label>Min Price</label>
+                <input
+                  type="number"
+                  value={minPrice}
+                  onChange={(e) => setMinPrice(e.target.value)}
+                />
+              </div>
+
+              <div className="filter-group">
+                <label>Max Price</label>
+                <input
+                  type="number"
+                  value={maxPrice}
+                  onChange={(e) => setMaxPrice(e.target.value)}
+                />
+              </div>
+
+              <div className="filter-actions">
+                <button onClick={applyFilters}>Apply</button>
+                <button
+                  className="reset"
+                  onClick={() => setShowFilters(false)}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+
       <div className="crypto-table">
-        <div data-aos="fade-up" className="table-layout">
+        <div className="table-layout">
           <p>#</p>
           <p>Coins</p>
           <p>Price</p>
           <p style={{ textAlign: "center" }}>24h Change</p>
           <p className="market-cap">Market Cap</p>
         </div>
+
         {displayCoin.slice(0, visibleCount).map((item, index) => (
-          <Link
-            to={`/coin/${item.id}`}
-            className="table-layout"
-            key={index} 
-            data-aos="fade-up"
-          >
+          <Link to={`/coin/${item.id}`} className="table-layout" key={index}>
             <p>{item.market_cap_rank}</p>
             <div>
-              <img src={item.image}></img>
-              <p>{item.name + " - " + item.symbol}</p>
+              <img src={item.image} alt={item.name} />
+              <p>{item.name} - {item.symbol}</p>
             </div>
-            <p>
-              {currency.Symbol}
-              {item.current_price.toLocaleString()}
-            </p>
-            <p
-              className={item.price_change_percentage_24h > 0 ? "green" : "red"}
-            >
-              {Math.floor(item.price_change_percentage_24h * 100) / 100}
+            <p>{currency.Symbol}{item.current_price.toLocaleString()}</p>
+            <p className={item.price_change_percentage_24h > 0 ? "green" : "red"}>
+              {item.price_change_percentage_24h.toFixed(2)}
             </p>
             <p className="market-cap">
-              {currency.Symbol}
-              {item.market_cap.toLocaleString()}
+              {currency.Symbol}{item.market_cap.toLocaleString()}
             </p>
           </Link>
         ))}
-        {/* LOAD MORE BUTTON */}
+
+        {/* Load More Button */}
         {visibleCount < displayCoin.length && (
           <div className="load-more">
-            <button onClick={loadMoreHandler}>Load More</button>
+            <button onClick={() => setVisibleCount(visibleCount + 10)}>
+              Load More
+            </button>
           </div>
         )}
-
       </div>
     </div>
   );


### PR DESCRIPTION
This PR introduces a new filter UI for cryptocurrency listings and positions it on the right side of the search bar for a cleaner, dashboard-style layout.

What this adds:
A filter panel for refining cryptocurrency listings using min and max price.
A toggleable filter icon next to the search bar.
A responsive layout where filters appear on the right on desktop and stack on smaller screens.

Why this is needed:
This feature improves coin discovery and provides users with better control over large datasets without cluttering the main layout.
---
## 🔗 Related Issue
Closes #46 

---

## 🛠 Type of Change
 ✨ Enhancement (improves existing functionality)
 🚀 New feature (adds new functionality)

---

## ✅ Checklist
 Code follows project coding standards - done
 Self-review completed - done
 Tests added or updated (not applicable for this UI change)
 Manual testing completed-done
 No new warnings or errors introduced - done
---

## 🧪 Testing Done
<img width="1098" height="742" alt="image" src="https://github.com/user-attachments/assets/085d11e7-5e9c-41b3-b711-494d94c61343" />
<img width="606" height="942" alt="image" src="https://github.com/user-attachments/assets/e66f8313-0675-41cf-b6e1-1fc1748de97b" />

---

## 🗒 Additional Notes
This PR focuses on the UI and basic filter logic.
Additional filters such as market cap, volume, and 24h change can be added in future iterations.
