### PR TITLE
Make footer year dynamic instead of static

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,6 +4,9 @@ import { Link } from 'react-router-dom';
 import { FaFacebook, FaTwitter, FaInstagram, FaGithub } from 'react-icons/fa';
 
 const Footer = () => {
+
+  const currentYear = new Date().getFullYear(); // dynamically fetch current year
+  
   return (
     <footer className="footer-container">
       <div className="footer-content">
@@ -48,7 +51,9 @@ const Footer = () => {
 
         {/* Copyright Line */}
         <div className="footer-bottom">
-          <p>Copyright © 2025, CryptoHub - All Rights Reserved.</p>
+          <p>
+            Copyright © {currentYear}, CryptoHub - All Rights Reserved.
+          </p>
         </div>
         
       </div>


### PR DESCRIPTION
# Pull Request Title
This PR updates the footer of CryptoHub to dynamically display the current year instead of a hardcoded value (2025).

---

## 📌 Description
Problem it solves:
Previously, the footer year was static and would require manual updates every year.
This update ensures the year automatically updates based on the user’s system date.

Changes made:
Replaced the static year in the footer with a dynamic year that updates automatically.
No other files or dependencies were changed.

---

## 🔗 Related Issue
Closes #100

---

## 🛠 Type of Change
- 🐛 Bug fix (non-breaking change fixing an issue)

---

## ✅ Checklist
<!-- Ensure all items are completed before requesting review -->
- Code follows project coding standards
- Self-review completed
- All tests passed locally
- No new warnings or errors introduced

---

## 🧪 Testing Done
Verified in-browser that the footer shows the current year dynamically.
Confirmed no other UI or functionality was affected.

---

## 🗒 Additional Notes
This is a non-breaking, minimal change focused solely on the footer.

Future enhancements could include adding dynamic copyright links or hover effects.

## Screenshot
<img width="1347" height="626" alt="Screenshot 2026-01-09 151920" src="https://github.com/user-attachments/assets/138e3f3d-721a-40d3-9964-fbb6945dc8ca" />

