### PR TITLE
Fix duplicate Top 5 Coins section rendering. Issue 107 solved

### DIFF
--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -258,23 +258,6 @@ const Features = () => {
           ))}
         </div>
       </div>
-
-      {/* TOP 5 COINS DISPLAY */}
-      <div className="top-coins-display">
-        <h3 className="top-coins-title">Top 5 Coins</h3>
-        <div className="coins-grid">
-          {topCoins.map((coin) => (
-            <div 
-              key={coin.id}
-              className={`coin-item ${selectedCoin === coin.id ? 'active' : ''}`}
-              onClick={() => setSelectedCoin(coin.id)}
-            >
-              <span className="coin-symbol">{coin.symbol}</span>
-              <span className="coin-name">{coin.name}</span>
-            </div>
-          ))}
-        </div>
-      </div>
       </motion.div>
 
       <div className="features-note">


### PR DESCRIPTION
Issue #107 Solved 
### 🐞 Bug Fix: Duplicate Top 5 Coins Section

This PR fixes an issue where the **Top 5 Coins** section was displayed twice on the page.

### ✅ What was fixed
- Removed duplicate rendering of the Top 5 Coins component
- Ensured the section renders only once

### 🛠️ How it was fixed
- Checked component usage
- Removed the extra component call

### 📸 Screenshots
- Before: Two identical Top 5 Coins sections
- After: Single Top 5 Coins section (expected behavior)
<img width="956" height="476" alt="image" src="https://github.com/user-attachments/assets/cef1ad87-0cd3-41bd-85b3-5f1864f24536" />


### 📌 Notes
- No UI or functionality regression
- Clean and minimal fix

@KaranUnique 