### PR TITLE
Add Terms of Service page with routing and footer link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,8 +26,8 @@ import { CoinContext } from "@/context/CoinContext";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { Toaster } from "react-hot-toast";
 import ScrollToTop from "@/components/ScrollToTop";
-import PrivacyPolicy from "@/pages/PrivacyPolicy.jsx";
-import TermsConditions from "@/pages/TermsConditions.jsx";
+import PrivacyPolicy from "@/components/PrivacyPolicy.jsx";
+import TermsOfService from "@/components/TermsOfService.jsx";
 
 const App = () => {
   const { isLoading } = useContext(CoinContext);
@@ -102,8 +102,6 @@ const App = () => {
                 <Route path="/market-overview" element={<MarketOverview />} />
                 <Route path="/leaderboard" element={<Leaderboard />} />
                 <Route path="/change-password" element={<ChangePassword />} />
-                <Route path="/privacy" element={<PrivacyPolicy />} />
-                <Route path="/terms" element={<TermsConditions />} />
               </Route>
 
               {/* Coin route - accessible to all but shows sidebar if logged in */}
@@ -112,7 +110,10 @@ const App = () => {
               {/* Add 404 Route if you implemented it earlier */}
               {/* <Route path="*" element={<NotFound />} /> */}
 
-              <Route path="/privacy" element={<PrivacyPolicy />} />
+            <Route path="/privacy" element={<PrivacyPolicy />} />
+            <Route path="/terms" element=
+            {<TermsOfService />} />
+
 
 
             </Routes>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -138,9 +138,9 @@ const Footer = () => {
 
           <div className="footer-bottom">
             <p>
-              <Link to="/privacy">Privacy</Link> •
-              <Link to="/terms"> Terms</Link> •
-              <Link to="/cookies"> Cookies</Link>
+              <Link to="/privacy">Privacy Policy</Link> |{" "}
+              <Link to="/terms">Terms of Service</Link> |{" "}
+              <Link to="/cookies">Cookies</Link>
             </p>
             <p>© {currentYear} CryptoHub. All rights reserved.</p>
           </div>

--- a/src/components/TermsOfService.css
+++ b/src/components/TermsOfService.css
@@ -1,0 +1,96 @@
+/* TermsOfService.css - Scoped & Simple */
+.terms-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 100%);
+  padding: 2rem;
+  color: #e5e5e5;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.terms-content {
+  max-width: 800px;
+  margin: 0 auto;
+  background: rgba(15, 15, 35, 0.95);
+  border-radius: 20px;
+  padding: 3rem;
+  border: 1px solid rgba(255,255,255,0.1);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+}
+
+.terms-content h1 {
+  font-size: 2.5rem;
+  background: linear-gradient(135deg, #fff, #ccc);
+  -webkit-background-clip: text;
+  background-clip: text;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-weight: 700;
+}
+
+.last-updated {
+  text-align: center;
+  color: #aaa;
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+
+section {
+  margin-bottom: 2.5rem;
+  opacity: 0;
+  animation: fadeIn 0.6s ease forwards;
+}
+
+@keyframes fadeIn {
+  to { opacity: 1; }
+}
+
+section h2 {
+  font-size: 1.6rem;
+  color: #fff;
+  margin-bottom: 1.2rem;
+  padding-left: 1rem;
+  border-left: 3px solid #f7931e;
+}
+
+p {
+  line-height: 1.7;
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+  color: #d0d0d0;
+}
+
+ul {
+  padding-left: 1.5rem;
+  list-style: none;
+}
+
+ul li {
+  position: relative;
+  margin-bottom: 0.8rem;
+  font-size: 1.05rem;
+  color: #d0d0d0;
+}
+
+
+strong {
+  color: #fff;
+  font-weight: 600;
+}
+
+.email {
+  color: #f7931e !important;
+  font-weight: 500;
+  font-size: 1.1rem;
+  background: rgba(247,147,30,0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1px solid rgba(247,147,30,0.3);
+  display: inline-block;
+}
+
+@media (max-width: 768px) {
+  .terms-container { padding: 1rem; }
+  .terms-content { padding: 2rem 1.5rem; border-radius: 16px; }
+  .terms-content h1 { font-size: 2rem; }
+  section h2 { font-size: 1.4rem; }
+}

--- a/src/components/TermsOfService.jsx
+++ b/src/components/TermsOfService.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import "./TermsOfService.css";
+
+const TermsOfService = () => {
+  return (
+    <div className="terms-container">
+      <div className="terms-content">
+        <h1>Terms of Service</h1>
+        <p className="last-updated">Last updated: January 2026</p>
+
+        <section>
+          <h2>1. Introduction</h2>
+          <p>
+            Welcome to <strong>CryptoHub</strong>. By accessing or using our
+            website and services, you agree to follow these Terms of Service.
+            Please read them carefully.
+          </p>
+        </section>
+
+        <section>
+          <h2>2. Use of Our Services</h2>
+          <ul>
+            <li>You must be at least 18 years old to use our platform.</li>
+            <li>You agree to provide accurate information when creating an account.</li>
+            <li>You are responsible for keeping your login credentials secure.</li>
+            <li>You agree not to misuse or harm the platform.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>3. Account Responsibilities</h2>
+          <p>
+            You are fully responsible for all activities that occur under your
+            account. If you notice unauthorized access, please contact us immediately.
+          </p>
+        </section>
+
+        <section>
+          <h2>4. Intellectual Property</h2>
+          <p>
+            All content on CryptoHub including logos, text, graphics, and design
+            belongs to us and is protected by copyright laws. You may not copy,
+            modify, or distribute without permission.
+          </p>
+        </section>
+
+        <section>
+          <h2>5. Payments and Subscriptions</h2>
+          <p>
+            If you purchase premium services, you agree to pay the listed fees.
+            All payments are non-refundable unless otherwise stated.
+          </p>
+        </section>
+
+        <section>
+          <h2>6. Limitation of Liability</h2>
+          <p>
+            CryptoHub provides cryptocurrency information and analytics for
+            educational purposes only. We are not responsible for financial
+            losses resulting from trading decisions.
+          </p>
+        </section>
+
+        <section>
+          <h2>7. Termination</h2>
+          <p>
+            We reserve the right to suspend or terminate accounts that violate
+            these terms without prior notice.
+          </p>
+        </section>
+
+        <section>
+          <h2>8. Changes to Terms</h2>
+          <p>
+            We may update these Terms of Service at any time. Continued use of
+            the platform means you accept the updated terms.
+          </p>
+        </section>
+
+        <section>
+          <h2>9. Contact Us</h2>
+          <p>
+            If you have questions about these Terms, contact us at:
+          </p>
+          <p className="email">support@cryptohub.com</p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default TermsOfService;


### PR DESCRIPTION
closes #157 

<img width="781" height="476" alt="terms service 1" src="https://github.com/user-attachments/assets/1eca281c-e2ef-4a73-bcfa-f0aef802b876" />
<img width="733" height="414" alt="terms service 2 " src="https://github.com/user-attachments/assets/bdc9f342-b351-47c9-802b-7f55b14fc9ba" />

##  PR Description:

This PR adds a Terms of Service page to the application.

Changes made:

Created TermsOfService.jsx page

Added CSS styling for clean UI

Added route in App.jsx

Linked Terms page in Footer

The page is publicly accessible and follows the same structure as the Privacy Policy page.

## under wocs 
@KaranUnique 
