### PR TITLE
Hide footer on auth-related pages #164

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,9 @@ const App = () => {
     location.pathname === "/market-overview" ||
     location.pathname === "/change-password" ;
 
+  const authRoutes = ["/login", "/signup", "/forgot-password"];
+  const isAuthPage = authRoutes.includes(location.pathname);
+
   useEffect(() => {
     AOS.init({
       duration: 1000,
@@ -135,7 +138,7 @@ const App = () => {
                 <Route path="/cookies" element={<CookiePolicy />} />
               </Routes>
             </div>
-            {!isDashboard && <Footer />}
+           {!isDashboard && !isAuthPage && <Footer />}
           </div>
           <ScrollToTop />
         </AuthProvider>


### PR DESCRIPTION
FIXED #164 

**Description**
Hide Footer on authentication pages (/login, /signup, /forgot-password) while keeping it visible on Home and Blog pages to   improve UI focus.



**CHANGES MADE**

- Added conditional rendering in App.jsx to hide the Footer on authentication pages.
- Footer is now hidden on /login, /signup, and /forgot-password routes.
- Footer remains visible on other pages like Home and Blog.
- Improved UI focus and cleanliness on auth pages.
- Verified changes don’t affect other components or routes.


**Checklist**

- Verified Footer is hidden on /login, /signup, and /forgot-password.
- Verified Footer is visible on Home and Blog pages.
- Ran the app locally (npm start) and checked UI for correctness.
- Ensured no other components or routes are affected.

<img width="1736" height="916" alt="Screenshot 2026-02-06 203049" src="https://github.com/user-attachments/assets/c171e8d6-6ea1-4fb3-931e-6e6f5be7ee93" />
<img width="1626" height="909" alt="Screenshot 2026-02-06 203109" src="https://github.com/user-attachments/assets/52c9c0a2-eb5d-4a68-b124-c070d01a0d6b" />
<img width="1483" height="872" alt="Screenshot 2026-02-06 203130" src="https://github.com/user-attachments/assets/737129fa-1e7f-4fdf-a3d2-e0ca1522a98e" />
