### PR TITLE
fix: make login and signup buttons visible in mobile menu (#249, #266)

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -1338,6 +1338,7 @@
   padding: 0.875rem 1rem;
   font-size: 0.95rem;
   font-weight: 600;
+  display: block;
 }
 
 .mobile-auth .navbar-btn-login {


### PR DESCRIPTION
Please add relevant labels and merge
Thanks!

## 📌 Description
This PR fixes a bug where the "Login" and "Get Started" buttons were hidden in the mobile view menu.

**What problem does it solve?**
- In mobile view, the authentication buttons were inadvertently hidden by a CSS selection rule intended for the desktop header layout.
- Use of `.mobile-auth` container now correctly displays these buttons as block elements in the slide-out menu.

## 🔗 Related Issue
Fixes #249

Closes #266
Closes #231 

## 🛠 Type of Change
- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## ✅ Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Tested on valid mobile resolutions