### PR TITLE
Fix: Persist Bookmarked Insights and Add Saved Insights Section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext,useRef } from "react";
+import React, { useEffect, useContext, useRef } from "react";
 import Lenis from "@studio-freight/lenis";
 import Navbar from "@/components/Navbar";
 import { Routes, Route, useLocation } from "react-router-dom";
@@ -16,6 +16,7 @@ import DashboardContent from "@/pages/Dashboard/DashboardContent";
 import MarketOverview from "@/pages/Dashboard/MarketOverview";
 import Leaderboard from "@/components/Leaderboard";
 import ChangePassword from "@/components/ChangePassword";
+import SavedInsights from "@/pages/SavedInsights";
 import ForgotPassword from "@/components/ForgotPassword";
 import PrivateRoute from "@/components/PrivateRoute";
 import { AuthProvider } from "@/context/AuthContext";
@@ -67,7 +68,8 @@ const App = () => {
     location.pathname === "/dashboard" ||
     location.pathname === "/leaderboard" ||
     location.pathname === "/market-overview" ||
-    location.pathname === "/change-password" ;
+    location.pathname === "/change-password" ||
+    location.pathname === "/saved-insights";
 
   const authRoutes = ["/login", "/signup", "/forgot-password"];
   const isAuthPage = authRoutes.includes(location.pathname);
@@ -143,6 +145,7 @@ const App = () => {
                   <Route path="/market-overview" element={<MarketOverview />} />
                   <Route path="/leaderboard" element={<Leaderboard />} />
                   <Route path="/change-password" element={<ChangePassword />} />
+                  <Route path="/saved-insights" element={<SavedInsights />} />
                 </Route>
 
                 {/* Coin route - accessible to all but shows sidebar if logged in */}
@@ -164,9 +167,9 @@ const App = () => {
                 <Route path="/cookies" element={<CookiePolicy />} />
               </Routes>
             </div>
-           {!isDashboard && !isAuthPage && <Footer />}
+            {!isDashboard && !isAuthPage && <Footer />}
           </div>
-          <ScrollToTop  lenis={lenisRef.current} />
+          <ScrollToTop lenis={lenisRef.current} />
         </AuthProvider>
       </ThemeProvider>
     </>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useTheme } from "../context/ThemeContext";
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { FiLock, FiUser, FiLogOut, FiMail } from "react-icons/fi";
+import { FiLock, FiUser, FiLogOut, FiMail, FiBookmark } from "react-icons/fi";
 import "./Navbar.css";
 
 function Navbar() {
@@ -221,6 +221,15 @@ function Navbar() {
                         <span>Change Password</span>
                       </Link>
                     )}
+
+                    <Link
+                      to="/saved-insights"
+                      className="profile-dropdown-item"
+                      onClick={() => setIsProfileOpen(false)}
+                    >
+                      <FiBookmark />
+                      <span>Saved Insights</span>
+                    </Link>
 
                     <button
                       onClick={() => {

--- a/src/pages/Dashboard/DashboardLayout.jsx
+++ b/src/pages/Dashboard/DashboardLayout.jsx
@@ -55,6 +55,15 @@ const DashboardLayout = () => {
             label: "Leaderboard",
             path: "/leaderboard"
         },
+        {
+            icon: (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                </svg>
+            ),
+            label: "Saved Insights",
+            path: "/saved-insights"
+        },
     ];
 
     return (

--- a/src/pages/SavedInsights.jsx
+++ b/src/pages/SavedInsights.jsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
+import { useAuth } from "../context/AuthContext";
+import { getBookmarks, toggleBookmark } from "../services/bookmarkService";
+import { generateBlogPosts } from "../components/Blog";
+import { FiBookmark, FiArrowLeft, FiLoader } from "react-icons/fi";
+import { toast } from "react-hot-toast";
+
+const SavedInsights = () => {
+    const navigate = useNavigate();
+    const { currentUser } = useAuth();
+    const [loading, setLoading] = useState(true);
+    const [savedPosts, setSavedPosts] = useState([]);
+    const allPosts = generateBlogPosts();
+
+    useEffect(() => {
+        const fetchSavedPosts = async () => {
+            if (!currentUser) {
+                setLoading(false);
+                return;
+            }
+
+            try {
+                const bookmarkIds = await getBookmarks(currentUser.uid);
+                // Filter posts that are in the bookmarkIds array
+                const filtered = allPosts.filter(post => bookmarkIds.includes(post.id));
+                setSavedPosts(filtered);
+            } catch (error) {
+                console.error("Error fetching saved insights:", error);
+                toast.error("Failed to load saved insights");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchSavedPosts();
+    }, [currentUser]);
+
+    const handleRemoveBookmark = async (e, blogId) => {
+        e.stopPropagation();
+        if (!currentUser) return;
+
+        try {
+            await toggleBookmark(currentUser.uid, blogId);
+            setSavedPosts(prev => prev.filter(post => post.id !== blogId));
+            toast.success("Removed from bookmarks");
+        } catch (error) {
+            console.error("Error removing bookmark:", error);
+            toast.error("Failed to remove bookmark");
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-[#0a0a1a] text-white">
+                <FiLoader className="animate-spin text-4xl text-[#4559DC]" />
+            </div>
+        );
+    }
+
+    if (!currentUser) {
+        return (
+            <div className="min-h-screen flex flex-col items-center justify-center bg-[#0a0a1a] text-white p-4">
+                <h2 className="text-2xl font-bold mb-4">Please log in to view saved insights</h2>
+                <button
+                    onClick={() => navigate("/login")}
+                    className="px-6 py-2 bg-[#4559DC] rounded-lg hover:bg-[#3548c0] transition-colors"
+                >
+                    Login
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-[#0a0a1a] text-white p-6 lg:p-10">
+            <div className="max-w-7xl mx-auto">
+                <header className="mb-8">
+                    <button
+                        onClick={() => navigate(-1)}
+                        className="flex items-center text-gray-400 hover:text-white mb-4 transition-colors"
+                    >
+                        <FiArrowLeft className="mr-2" /> Back
+                    </button>
+                    <div className="flex items-center gap-3">
+                        <FiBookmark className="text-3xl text-[#4559DC]" />
+                        <h1 className="text-3xl font-bold">Saved Insights</h1>
+                    </div>
+                    <p className="text-gray-400 mt-2">
+                        You have {savedPosts.length} saved article{savedPosts.length !== 1 ? 's' : ''}
+                    </p>
+                </header>
+
+                {savedPosts.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-20 bg-[#ffffff05] rounded-2xl border border-[#ffffff10]">
+                        <FiBookmark className="text-6xl text-gray-600 mb-4" />
+                        <h3 className="text-xl font-semibold mb-2">No saved insights yet</h3>
+                        <p className="text-gray-400 mb-6">Bookmark articles to read them later</p>
+                        <button
+                            onClick={() => navigate("/blog")}
+                            className="px-6 py-2 bg-[#4559DC] rounded-lg hover:bg-[#3548c0] transition-colors"
+                        >
+                            Browse Insights
+                        </button>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {savedPosts.map((post) => (
+                            <motion.article
+                                key={post.id}
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                className="bg-[#1a1a2e] rounded-xl overflow-hidden border border-[#ffffff10] hover:border-[#4559DC50] transition-all group cursor-pointer"
+                                onClick={() => navigate(`/blog/${post.id}`)}
+                            >
+                                <div className="relative h-48 overflow-hidden">
+                                    <img
+                                        src={post.image}
+                                        alt={post.title}
+                                        className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+                                    />
+                                    <div className="absolute top-3 right-3">
+                                        <button
+                                            onClick={(e) => handleRemoveBookmark(e, post.id)}
+                                            className="p-2 bg-black/50 backdrop-blur-sm rounded-full text-white hover:bg-red-500/80 transition-colors"
+                                            title="Remove from saved"
+                                        >
+                                            <FiBookmark className="fill-current" />
+                                        </button>
+                                    </div>
+                                    <div className="absolute top-3 left-3">
+                                        <span
+                                            className="px-3 py-1 text-xs font-medium rounded-full text-white"
+                                            style={{ background: post.badgeColor || "#4559DC" }}
+                                        >
+                                            {post.category}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="p-5">
+                                    <div className="flex items-center gap-2 mb-3 text-sm text-gray-400">
+                                        <span>{post.date}</span>
+                                        <span>•</span>
+                                        <span>{post.readTime}</span>
+                                    </div>
+
+                                    <h3 className="text-xl font-bold mb-3 line-clamp-2 group-hover:text-[#4559DC] transition-colors">
+                                        {post.title}
+                                    </h3>
+
+                                    <p className="text-gray-400 text-sm line-clamp-3 mb-4">
+                                        {post.excerpt}
+                                    </p>
+
+                                    <div className="flex items-center text-[#4559DC] text-sm font-medium">
+                                        Read Article
+                                        <svg className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                                        </svg>
+                                    </div>
+                                </div>
+                            </motion.article>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default SavedInsights;

--- a/src/services/bookmarkService.js
+++ b/src/services/bookmarkService.js
@@ -1,0 +1,56 @@
+import { doc, updateDoc, arrayUnion, arrayRemove, getDoc, setDoc } from "firebase/firestore";
+import { db } from "../firebase";
+
+/**
+ * Toggles bookmark status for a blog post
+ * @param {string} userId - Current user's ID
+ * @param {number|string} blogId - ID of the blog post
+ * @returns {Promise<boolean>} - Returns true if bookmarked, false if removed
+ */
+export const toggleBookmark = async (userId, blogId) => {
+    if (!userId) throw new Error("User must be logged in to bookmark");
+
+    const userRef = doc(db, "users", userId);
+    const userDoc = await getDoc(userRef);
+
+    if (!userDoc.exists()) {
+        // Should not happen for logged in users, but safety check
+        await setDoc(userRef, { bookmarks: [blogId] }, { merge: true });
+        return true;
+    }
+
+    const userData = userDoc.data();
+    const bookmarks = userData.bookmarks || [];
+    const isBookmarked = bookmarks.includes(blogId);
+
+    if (isBookmarked) {
+        await updateDoc(userRef, {
+            bookmarks: arrayRemove(blogId)
+        });
+        return false;
+    } else {
+        await updateDoc(userRef, {
+            bookmarks: arrayUnion(blogId)
+        });
+        return true;
+    }
+};
+
+/**
+ * continued...
+ * Fetches all bookmarked blog IDs for a user
+ * @param {string} userId - Current user's ID
+ * @returns {Promise<Array<string|number>>} - Array of bookmarked blog IDs
+ */
+export const getBookmarks = async (userId) => {
+    if (!userId) return [];
+
+    const userRef = doc(db, "users", userId);
+    const userDoc = await getDoc(userRef);
+
+    if (userDoc.exists()) {
+        return userDoc.data().bookmarks || [];
+    }
+
+    return [];
+};


### PR DESCRIPTION
## Summary
This PR fixes the incomplete Bookmark feature on the Insights page by ensuring bookmarked articles are properly persisted and accessible through a dedicated Saved Insights section.

---

## Problem
Currently, bookmarking an Insight article shows a success toast, but:
- The bookmark is not persisted
- There is no Saved / Bookmarked Insights section
- Users cannot revisit or manage bookmarked content

This results in a misleading UX and breaks the content engagement flow.

---

## Changes Implemented
- Persist bookmarked Insight articles (Firestore / backend layer)
- Introduce a **Saved Insights** section accessible from Dashboard / Sidebar
- Display all bookmarked Insight articles in a list/grid view
- Enable navigation to bookmarked articles
- Allow users to remove bookmarks
- Ensure bookmarks persist across refresh and sessions
- Keep visual feedback (toast + icon state)
 solve #276 
---

## Expected Behavior After Fix
- Bookmarking an Insight:
  - Saves it persistently
  - Updates bookmark state instantly
- Users can:
  - View all saved Insight articles
  - Navigate to saved content
  - Remove bookmarks
- Bookmark feature now works end-to-end as expected


## Impact
- Restores trust in the Bookmark feature
- Improves content retention and engagement
- Makes Insights feature fully usable
- Aligns UI feedback with real data behavior

---

## Checklist
-  Bookmark persistence implemented
-  Saved Insights UI added
-  Works across refresh and navigation
-  No breaking changes

---

Please review and let me know if any improvements are needed 🙌
<img width="1918" height="905" alt="Screenshot 2026-02-11 235600" src="https://github.com/user-attachments/assets/5f1d38a8-cddc-4435-9add-255896a08046" />
OSCG 2026